### PR TITLE
Fix broken Avalanche Consensus white paper link

### DIFF
--- a/src/Snow.tsx
+++ b/src/Snow.tsx
@@ -325,7 +325,7 @@ class Snow extends React.Component<SnowProps> {
             <Grid item lg={4} xs={12}>
               <Typography variant="body1" paragraph>
                 This demo shows the Snowball protocol used as the core of a peer-to-peer payment system, Avalanche, introduced in&nbsp;
-                <Link href="https://avalabs.org/QmT1ry38PAmnhparPUmsUNHDEGHQusBLD6T5XJh4mUUn3v.pdf" target="_blank" rel="noopener">
+                <Link href="https://arxiv.org/pdf/1906.08936.pdf" target="_blank" rel="noopener">
                   this paper
                 </Link>
                 &nbsp;. It visualizes the process of a binary,


### PR DESCRIPTION
The link pointing to avalabs.org is broken, since the file has been moved to a new domain. Therefore, I propose changing the link to arXiv link. 

If it's desired to use the same link used on the Ava Labs website this would be it: https://assets-global.website-files.com/5d80307810123f5ffbb34d6e/6009805681b416f34dcae012_Avalanche%20Consensus%20Whitepaper.pdf